### PR TITLE
Fix missing return

### DIFF
--- a/visualization/motion_planning_tasks/properties/property_from_yaml.cpp
+++ b/visualization/motion_planning_tasks/properties/property_from_yaml.cpp
@@ -161,6 +161,7 @@ rviz_common::properties::Property* Parser::process(const yaml_event_t& event, co
 			break;
 	}
 	assert(false);  // should not be reached
+	return nullptr;
 }
 
 // Try to set numeric or arbitrary scalar value from YAML node. Needs to match old's type.


### PR DESCRIPTION
The existing assert does not indicate to the compiler a proper path of execution, and results in the following warning. 

```
visualization/motion_planning_tasks/properties/property_from_yaml.cpp: In member function ‘rviz_common::properties::Property* {anonymous}::Parser::process(const yaml_event_t&, const QString&, const QString&, rviz_common::properties::Property*) const’:
visualization/motion_planning_tasks/properties/property_from_yaml.cpp:164:1: warning: control reaches end of non-void function [-Wreturn-type]
  164 | }
      | ^
---

```