### PR TITLE
Set C++17 as default and address header deprecation warnings

### DIFF
--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -14,7 +14,9 @@ find_package(rviz_marker_tools REQUIRED)
 find_package(tf2_eigen REQUIRED)
 find_package(visualization_msgs REQUIRED)
 
-set(CMAKE_CXX_STANDARD 17)
+if(NOT CMAKE_CXX_STANDARD)
+  set(CMAKE_CXX_STANDARD 17)
+endif()
 
 add_compile_options(-fvisibility-inlines-hidden)
 

--- a/core/src/solvers/pipeline_planner.cpp
+++ b/core/src/solvers/pipeline_planner.cpp
@@ -43,7 +43,7 @@
 #include <moveit_msgs/msg/motion_plan_request.hpp>
 #include <moveit/kinematic_constraints/utils.h>
 
-#include <tf2_eigen/tf2_eigen.h>
+#include <tf2_eigen/tf2_eigen.hpp>
 
 namespace moveit {
 namespace task_constructor {

--- a/core/src/stages/compute_ik.cpp
+++ b/core/src/stages/compute_ik.cpp
@@ -43,7 +43,7 @@
 #include <moveit/robot_state/robot_state.h>
 
 #include <Eigen/Geometry>
-#include <tf2_eigen/tf2_eigen.h>
+#include <tf2_eigen/tf2_eigen.hpp>
 #include <chrono>
 #include <functional>
 #include <iterator>

--- a/core/src/stages/fix_collision_objects.cpp
+++ b/core/src/stages/fix_collision_objects.cpp
@@ -43,7 +43,7 @@
 #include <moveit/task_constructor/cost_terms.h>
 
 #include <rviz_marker_tools/marker_creation.h>
-#include <tf2_eigen/tf2_eigen.h>
+#include <tf2_eigen/tf2_eigen.hpp>
 #include <Eigen/Geometry>
 #include <rclcpp/logging.hpp>
 

--- a/core/src/stages/generate_grasp_pose.cpp
+++ b/core/src/stages/generate_grasp_pose.cpp
@@ -42,7 +42,7 @@
 #include <moveit/planning_scene/planning_scene.h>
 
 #include <Eigen/Geometry>
-#include <tf2_eigen/tf2_eigen.h>
+#include <tf2_eigen/tf2_eigen.hpp>
 
 namespace moveit {
 namespace task_constructor {

--- a/core/src/stages/generate_place_pose.cpp
+++ b/core/src/stages/generate_place_pose.cpp
@@ -43,7 +43,7 @@
 #include <moveit/robot_state/attached_body.h>
 
 #include <Eigen/Geometry>
-#include <tf2_eigen/tf2_eigen.h>
+#include <tf2_eigen/tf2_eigen.hpp>
 
 namespace moveit {
 namespace task_constructor {

--- a/core/src/stages/move_relative.cpp
+++ b/core/src/stages/move_relative.cpp
@@ -41,7 +41,7 @@
 
 #include <moveit/planning_scene/planning_scene.h>
 #include <rviz_marker_tools/marker_creation.h>
-#include <tf2_eigen/tf2_eigen.h>
+#include <tf2_eigen/tf2_eigen.hpp>
 
 namespace moveit {
 namespace task_constructor {

--- a/core/src/stages/move_to.cpp
+++ b/core/src/stages/move_to.cpp
@@ -41,7 +41,7 @@
 
 #include <moveit/planning_scene/planning_scene.h>
 #include <rviz_marker_tools/marker_creation.h>
-#include <tf2_eigen/tf2_eigen.h>
+#include <tf2_eigen/tf2_eigen.hpp>
 #include <moveit/robot_state/conversions.h>
 
 namespace moveit {

--- a/core/src/stages/simple_grasp.cpp
+++ b/core/src/stages/simple_grasp.cpp
@@ -44,7 +44,7 @@
 #include <moveit/planning_scene/planning_scene.h>
 
 #include <Eigen/Geometry>
-#include <tf2_eigen/tf2_eigen.h>
+#include <tf2_eigen/tf2_eigen.hpp>
 
 namespace moveit {
 namespace task_constructor {

--- a/demo/include/moveit_task_constructor_demo/pick_place_task.h
+++ b/demo/include/moveit_task_constructor_demo/pick_place_task.h
@@ -60,7 +60,7 @@
 
 #include <rclcpp_action/rclcpp_action.hpp>
 
-#include <tf2_eigen/tf2_eigen.h>
+#include <tf2_eigen/tf2_eigen.hpp>
 
 #pragma once
 

--- a/rviz_marker_tools/CMakeLists.txt
+++ b/rviz_marker_tools/CMakeLists.txt
@@ -9,7 +9,9 @@ find_package(eigen3_cmake_module REQUIRED)
 find_package(Eigen3 REQUIRED)
 find_package(tf2_eigen REQUIRED)
 
-set(CMAKE_CXX_STANDARD 14)
+if(NOT CMAKE_CXX_STANDARD)
+  set(CMAKE_CXX_STANDARD 17)
+endif()
 
 set(PROJECT_INCLUDE ${CMAKE_CURRENT_SOURCE_DIR}/include/${PROJECT_NAME})
 

--- a/rviz_marker_tools/src/marker_creation.cpp
+++ b/rviz_marker_tools/src/marker_creation.cpp
@@ -1,6 +1,6 @@
 #include <rviz_marker_tools/marker_creation.h>
 #include <urdf_model/link.h>
-#include <tf2_eigen/tf2_eigen.h>
+#include <tf2_eigen/tf2_eigen.hpp>
 #include <rclcpp/logging.hpp>
 
 static const rclcpp::Logger LOGGER = rclcpp::get_logger("rviz_marker_tools");

--- a/visualization/CMakeLists.txt
+++ b/visualization/CMakeLists.txt
@@ -27,7 +27,9 @@ set(CMAKE_AUTOMOC ON)
 set(CMAKE_AUTORCC ON)
 add_definitions(-DQT_NO_KEYWORDS)
 
-set(CMAKE_CXX_STANDARD 14)
+if(NOT CMAKE_CXX_STANDARD)
+  set(CMAKE_CXX_STANDARD 17)
+endif()
 
 add_subdirectory(visualization_tools)
 add_subdirectory(motion_planning_tasks)

--- a/visualization/visualization_tools/src/marker_visualization.cpp
+++ b/visualization/visualization_tools/src/marker_visualization.cpp
@@ -11,7 +11,7 @@
 #include <OgreSceneNode.h>
 #include <tf2_msgs/msg/tf2_error.hpp>
 #include <rclcpp/logging.hpp>
-#include <tf2_eigen/tf2_eigen.h>
+#include <tf2_eigen/tf2_eigen.hpp>
 
 static const rclcpp::Logger LOGGER = rclcpp::get_logger("moveit_task_constructor_visualization.marker_visualization");
 


### PR DESCRIPTION
Fixes needed to build on Rolling.
- Use C++17 as default, and add check to see if `CMAKE_CXX_STANDARD` is already set.
- Switch from `.h` to `.hpp` for `tf2_eigen` headers.