### PR TITLE
Use trajectory execution info from parent only if controller list is empty

### DIFF
--- a/core/src/container.cpp
+++ b/core/src/container.cpp
@@ -359,7 +359,9 @@ void ContainerBase::insert(Stage::pointer&& stage, int before) {
 	if (!stage)
 		throw std::runtime_error(name() + ": received invalid stage pointer");
 
-	stage->setTrajectoryExecutionInfo(this->trajectoryExecutionInfo());
+	if (stage->trajectoryExecutionInfo().controller_names.empty()) {
+		stage->setTrajectoryExecutionInfo(this->trajectoryExecutionInfo());
+	}
 
 	StagePrivate* impl = stage->pimpl();
 	impl->setParent(this);


### PR DESCRIPTION
This resolves a bug where overriding trajectory execution info for a stage will be ignored in favor of the task's trajectory execution info.